### PR TITLE
xxbuild: make summary more readable

### DIFF
--- a/xxbuild
+++ b/xxbuild
@@ -1,12 +1,32 @@
 #!/bin/sh
 # xxbuild [flags] [pkgs..] - build packages for a pre-defined set of archs
+# set NO_COLUMN and/or NO_COLOR for easier-to-parse output
 
 : "${XXBUILD_ARCHS:="x86_64 x86_64-musl i686 aarch64-musl aarch64 armv7l-musl armv7l armv6l-musl armv6l"}"
 : "${XBPS_HOSTDIR:="$HOME/.cache/xxtools/hostdir"}"
 : "${XBPS_MASTERDIR:="$(xdistdir)/masterdir.xxtools"}"
 : "${XXBUILD_HOSTARCH:="$(xbps-uhelper arch || uname -m)"}"
 
+if [ -z "$NO_COLUMN" ] && command -v column >/dev/null; then
+	COLUMN="column -ts:"
+else
+	COLUMN="cat"
+fi
+
 cd "$(xdistdir)" || exit 1
+
+text_bold() {
+	[ -z "$NO_COLOR" ] && printf '\033[1m%s\033[m' "$@" || printf "$@"
+}
+text_red() {
+	[ -z "$NO_COLOR" ] && printf '\033[31m%s\033[m' "$@" || printf "$@"
+}
+text_green() {
+	[ -z "$NO_COLOR" ] && printf '\033[32m%s\033[m' "$@" || printf "$@"
+}
+text_yellow() {
+	[ -z "$NO_COLOR" ] && printf '\033[33m%s\033[m' "$@" || printf "$@"
+}
 
 target_arch_can_run_natively() {
 	#TODO: ppc
@@ -37,14 +57,21 @@ _xbps_src() {
 	)
 }
 
-summary="$(printf '\n%s\n' "SUMMARY")"
+summary="$(printf '\n%s\n' "$(text_bold SUMMARY)")"
+if [ "$COLUMN" != "cat" ]; then
+	summary="$(printf '%s\n' "$summary" "$(text_bold pkg:host:target:cross:result)")"
+fi
 append_summary() {
 	pkg="$1"
 	host_arch="$2"
 	target_arch="$3"
 	cross="$4"
 	result="$5"
-	summary="$(printf '%s\n' "$summary" "pkg:${pkg} host:${host_arch} target:${target_arch} cross:${cross} result:${result}")"
+	if [ "$COLUMN" != "cat" ]; then
+		summary="$(printf '%s\n' "$summary" "${pkg}:${host_arch}:${target_arch}:${cross}:${result}")"
+	else
+		summary="$(printf '%s\n' "$summary" "pkg:${pkg} host:${host_arch} target:${target_arch} cross:${cross} result:${result}")"
+	fi
 }
 
 xbps_src_flags=
@@ -139,13 +166,13 @@ for target_arch in $XXBUILD_ARCHS; do
 		result=
 		case "$ret" in
 			0)
-				result="OK"
+				result="$(text_green OK)"
 				;;
 			2) # nocross, broken or no match in `archs=`
-				result="SKIPPED"
+				result="$(text_yellow SKIPPED)"
 				;;
 			*)
-				result="FAILED"
+				result="$(text_red FAILED)"
 				[ -n "$xxbuild_keep_going" ] || bailout=y
 				;;
 		esac
@@ -156,5 +183,5 @@ for target_arch in $XXBUILD_ARCHS; do
 	[ -z "$bailout" ] || break
 done
 
-echo "$summary"
+echo "$summary" | $COLUMN
 exit $ret


### PR DESCRIPTION
falls back to old layout if `column` isn't available, but still has coloured result and bold SUMMARY

![image](https://user-images.githubusercontent.com/5366828/204159385-6cc25085-d549-41d7-88d1-1e8b2dca3cf0.png)
