### PR TITLE
xxbuild: use musl host arch for musl target arch

### DIFF
--- a/xxbuild
+++ b/xxbuild
@@ -5,7 +5,7 @@
 : "${XXBUILD_ARCHS:="x86_64 x86_64-musl i686 aarch64-musl aarch64 armv7l-musl armv7l armv6l-musl armv6l"}"
 : "${XBPS_HOSTDIR:="$HOME/.cache/xxtools/hostdir"}"
 : "${XBPS_MASTERDIR:="$(xdistdir)/masterdir.xxtools"}"
-: "${XXBUILD_HOSTARCH:="$(xbps-uhelper arch || uname -m)"}"
+: "${XXBUILD_HOSTARCH:="$(uname -m)"}"
 
 if [ -z "$NO_COLUMN" ] && command -v column >/dev/null; then
 	COLUMN="column -ts:"
@@ -142,7 +142,10 @@ for target_arch in $XXBUILD_ARCHS; do
 		xbps_src_cross_flags=
 	else
 		cross=y
-		master_arch="$XXBUILD_HOSTARCH"
+		case "$target_arch" in
+			*-musl) master_arch="${XXBUILD_HOSTARCH}-musl" ;;
+			*) master_arch="${XXBUILD_HOSTARCH}" ;;
+		esac
 		xbps_src_cross_flags="-a $target_arch"
 	fi
 


### PR DESCRIPTION
there are a few packages that seem to break when crossbuilt cross-libc (mesa, for one)

example:
```
SUMMARY                                    
pkg      host         target        cross  result
chezmoi  x86_64       x86_64        n      OK
chezmoi  x86_64-musl  x86_64-musl   n      OK
chezmoi  i686         i686          n      OK
chezmoi  x86_64-musl  aarch64-musl  y      OK
chezmoi  x86_64       aarch64       y      OK
chezmoi  x86_64-musl  armv7l-musl   y      OK
chezmoi  x86_64       armv7l        y      OK
chezmoi  x86_64-musl  armv6l-musl   y      OK
chezmoi  x86_64       armv6l        y      OK
```